### PR TITLE
Remove dependence on removed Scheduler#parallelism method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'java'
 
 sourceCompatibility = 1.6
-version = '0.1'
+version = '0.2'
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compile 'io.reactivex:rxjava:1.0.0-rc.3'
+    compile 'io.reactivex:rxjava:1.0.4'
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }

--- a/src/test/java/me/ronshapiro/rx/priority/PrioritySchedulerTest.java
+++ b/src/test/java/me/ronshapiro/rx/priority/PrioritySchedulerTest.java
@@ -1,10 +1,14 @@
 package me.ronshapiro.rx.priority;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 
@@ -13,14 +17,17 @@ import rx.functions.Action1;
 import rx.schedulers.Schedulers;
 
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
 
+@RunWith(JUnit4.class)
 public class PrioritySchedulerTest {
 
     @Test
-    public void schedulesInOrderOfPriority() throws Exception {
-        PriorityScheduler scheduler = new PriorityScheduler(Executors.newSingleThreadExecutor());
+    public void schedulesInOrderOfPriorityWhenSingleThreaded() throws Exception {
+        final int parallelism = 1;
+        PriorityScheduler scheduler = PriorityScheduler.withConcurrency(parallelism);
 
-        final int count = 1000;
+        final int count = 10000;
         final CountDownLatch finishLatch = new CountDownLatch(count);
         final CountDownLatch loopLatch = new CountDownLatch(1);
         final List<Integer> actual = Collections.synchronizedList(new ArrayList<Integer>());
@@ -43,20 +50,49 @@ public class PrioritySchedulerTest {
         loopLatch.countDown();
         finishLatch.await();
 
-        final int parallelism = scheduler.priority(0).parallelism();
         List<Integer> subList = actual.subList(parallelism, actual.size());
         int last = Integer.MAX_VALUE;
         for (int i : subList) {
             if (last < i) {
-                System.out.println("actual: " + actual);
                 fail("actual was not monotonically decreasing after the first N items, where N " +
-                        "is the scheduler's parallelism/number of the cores on the machine. " +
-                        "failed at index " + actual.indexOf(i) + " (value = " + i + "). " +
-                        "Full list: " + actual);
+                     "is the scheduler's parallelism. failed at index " + actual.indexOf(i) +
+                     " (value = " + i + "). " + "Full list: " + actual);
             }
             last = i;
         }
     }
+
+    @Test
+    public void runsEachActionExactlyOnce_whenRunWithConcurrency() throws Exception {
+        final int parallelism = 10;
+        PriorityScheduler scheduler = PriorityScheduler.withConcurrency(parallelism);
+
+        final int count = 10000;
+        final CountDownLatch finishLatch = new CountDownLatch(count);
+        final CountDownLatch loopLatch = new CountDownLatch(1);
+        final Set<Integer> actual = Collections.synchronizedSet(new HashSet<Integer>());
+        final Object onNextLock = new Object();
+
+        for (int i = 0; i < count; i++) {
+            Observable.just(i)
+                    .subscribeOn(scheduler.priority(i))
+                    .subscribe(new Action1<Integer>() {
+                        @Override
+                        public void call(Integer integer) {
+                            synchronized (onNextLock) {
+                                await(loopLatch);
+                                actual.add(integer);
+                                finishLatch.countDown();
+                            }
+                        }
+                    });
+        }
+        loopLatch.countDown();
+        finishLatch.await();
+
+        assertEquals(count, actual.size());
+    }
+
 
     private static void await(CountDownLatch latch) {
         try {


### PR DESCRIPTION
Addresses #2. @MercurieVV, will you confirm this still fits for your use case? Note that it's a breaking change, with a removal of `new PriorityScheduler(ExecutorService)` since there is no longer an implicit `parallelism`, and the switch to static factories instead of public constructors. Assuming that's ok, I'll upgrade and push `0.2` to Maven Central.